### PR TITLE
refactor: Added --exit-code argument

### DIFF
--- a/.github/workflows/autopep8.yml
+++ b/.github/workflows/autopep8.yml
@@ -10,7 +10,7 @@ jobs:
       - name: autopep8
         uses: peter-evans/autopep8@v2
         with:
-          args: --recursive --in-place --aggressive --aggressive .
+          args: --exit-code --recursive --in-place --aggressive --aggressive .
       - name: Fail if autopep8 made changes
         if: steps.autopep8.outputs.exit-code == 2
         run: exit 1


### PR DESCRIPTION
Added the --exit-code argument, so that the second name action can check for the exit code.