### PR TITLE
refactor(autopep8): Removed If statement, so that actions will run on…

### DIFF
--- a/.github/workflows/autopep8.yml
+++ b/.github/workflows/autopep8.yml
@@ -2,8 +2,6 @@ name: autopep8
 on: pull_request
 jobs:
   autopep8:
-    # Check if the PR is not from a fork
-    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Prior, the autopep8 action would only run if the PR was from a none forked repo. By removing the IF statement, it should now run on any PR regardless of the status of the repo.